### PR TITLE
feat: 替换sun.misc.BASE64Decoder 支持Java 8 以上

### DIFF
--- a/src/main/java/com/amazon/spapi/config/AesUtil.java
+++ b/src/main/java/com/amazon/spapi/config/AesUtil.java
@@ -1,10 +1,10 @@
 package com.amazon.spapi.config;
 
-import sun.misc.BASE64Decoder;
-
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * <Description> <br>
@@ -33,17 +33,19 @@ public class AesUtil {
                 System.out.print("Key长度不是16位");
                 return null;
             }
-            byte[] raw = key.getBytes("ASCII"); //参数类型
+            byte[] raw = key.getBytes(StandardCharsets.US_ASCII);
             SecretKeySpec skeySpec = new SecretKeySpec(raw, "AES");
             Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");  //"算法/模式/补码方式"
             //CBC模式需要配置偏移量，设置这个后，不会出来同一个明文加密为同一个密文的问题，达到密文唯一性
             IvParameterSpec iv = new IvParameterSpec("1234567890123456".getBytes());
             cipher.init(Cipher.DECRYPT_MODE, skeySpec, iv);
-            byte[] encrypted1 = new BASE64Decoder().decodeBuffer(content);//先用base64解密
+
+            // Using java.util.Base64 instead of sun.misc.BASE64Decoder
+            byte[] encrypted1 = Base64.getDecoder().decode(content);
+
             try {
                 byte[] original = cipher.doFinal(encrypted1);
-                String originalString = new String(original);
-                return originalString;
+                return new String(original);
             } catch (Exception e) {
                 System.out.println(e.toString());
                 return null;


### PR DESCRIPTION
- 替换sun.misc.BASE64Decoder为java.util.Base64以提高代码的可移植性
- 使用StandardCharsets.US_ASCII替换"ASCII"字符串以提高代码的可读性和兼容性